### PR TITLE
Update NewRepositoryGuide.md

### DIFF
--- a/MailingLists.md
+++ b/MailingLists.md
@@ -15,7 +15,7 @@ to post via web or email, you can email that address to post new topics.
 
 If you completed onboarding more than two business days ago and are not receiving mail, 
 please check your spam folder and be sure to add CFDE@groups.io to your safe sender list
-in your email client’s contacts. If you are still experianceing difficulties, email our
+in your email client’s contacts. If you are still experiencing difficulties, email our
 [helpdesk](mailto:autohelp+int+851+6545985337373134556@CFDE.groups.io)
 
 ### Modifying your subscription

--- a/NewRepositoryGuide.md
+++ b/NewRepositoryGuide.md
@@ -16,7 +16,7 @@ If the repository will not host much code, consider whether a mailing list or Sl
   - Repositories that are created in the CFDE organization are able to
     take advantage of Github teams in the CFDE organization.
   - All repositories that are part of the CFDE project are subject to
-    the [CFDE Code of Conduct](https://github.com/nih-cfde/organization/blob/master/CODEOFCONDUCT.md).
+    the [CFDE Code of Conduct](./CODEOFCONDUCT.md).
 
 **2) Decide whether to make your repository public or private.**
 
@@ -73,8 +73,7 @@ If the repository will not host much code, consider whether a mailing list or Sl
 **7) Add a `CONTRIBUTING.md` that explains how to contribute to the
 repository.**
 
-  - Sample `CONTRIBUTING.md`:
-    <https://github.com/nih-cfde/organization/blob/master/CONTRIBUTING.md>
+  - Sample `CONTRIBUTING.md`: [CONTRIBUTING.md](./CONTRIBUTING.md)
 
 
 <a name="addendum"></a>

--- a/NewRepositoryGuide.md
+++ b/NewRepositoryGuide.md
@@ -73,7 +73,8 @@ If the repository will not host much code, consider whether a mailing list or Sl
 **7) Add a `CONTRIBUTING.md` that explains how to contribute to the
 repository.**
 
-  - Sample `CONTRIBUTING.md`: [CONTRIBUTING.md](./CONTRIBUTING.md)
+  - Sample `CONTRIBUTING.md`:
+    - [CONTRIBUTING.md](./CONTRIBUTING.md)
 
 
 <a name="addendum"></a>

--- a/NewRepositoryGuide.md
+++ b/NewRepositoryGuide.md
@@ -16,7 +16,7 @@ If the repository will not host much code, consider whether a mailing list or Sl
   - Repositories that are created in the CFDE organization are able to
     take advantage of Github teams in the CFDE organization.
   - All repositories that are part of the CFDE project are subject to
-    the [CFDE Code of Conduct](CODE_OF_CONDUCT.md).
+    the [CFDE Code of Conduct](https://github.com/nih-cfde/organization/blob/master/CODEOFCONDUCT.md).
 
 **2) Decide whether to make your repository public or private.**
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This is the central organizational repository for the Common Fund Data Ecosystem
 
 To modify or update this repository: create a pull
-request, file an issue, or [e-mail us](mailto:autohelp+int+851+6545985337373134556@CFDE.groups.io) with your
+request, file an issue, or [e-mail us](mailto:coordination+int+1481+4810093048235559374@CFDE.groups.io) with your
 request.
 
 ## Onboarding
@@ -13,7 +13,7 @@ GitHub, mailing list, calendars and other internal documents.
 
 If you are having trouble accessing something you believe you should have access to, please visit our
 [Onboarding Help](OnboardingHelp.md) or 
-email the [HelpDesk](mailto:autohelp+int+851+6545985337373134556@CFDE.groups.io)
+email the [HelpDesk](mailto:coordination+int+1481+4810093048235559374@CFDE.groups.io)
 
 ## General Resources
 


### PR DESCRIPTION
The previous link for the Code of Conduct was not working. It lead to a 404 page error. I replaced it with a full link to the CFDE Code of Conduct Page.