### PR TITLE
Update coordination e-mail links

### DIFF
--- a/infrastructure/OffboardingWorkflow.md
+++ b/infrastructure/OffboardingWorkflow.md
@@ -6,7 +6,7 @@ To offboard ,a member (or someone from their team) must:
  We track those events, as well as our progress in adding them to our resources [here](https://docs.google.com/spreadsheets/d/1bY-P5ZrIOPDrDpzlXNrDnV96XqOnV_X9z9ur7t9Qkhk/edit?usp=sharing).
 
 ## Offboarding Overview
-The Offboarding form will send notifications to coordination@CFDE.groups.io whenever the form is filled out. To request being added to coordination mailing list and receive notifications, send your request to the [helpdesk](mailto:autohelp+int+851+6545985337373134556@CFDE.groups.io).
+The Offboarding form will send notifications to coordination@CFDE.groups.io whenever the form is filled out. To request being added to coordination mailing list and receive notifications, send your request to the [helpdesk](mailto:coordination+int+1482+3914664481228082529@CFDE.groups.io).
 
 A member of the coordination mailing list should begin the onboarding process for new forms *within 2 business days*. Full onboarding for each person is a typically a multi-day process, and can be done by multiple memebers of the coordination team, because we have to wait for each new onboardee to accept the invitations. The basic workflow is:
 


### PR DESCRIPTION
Replaced the link in Help Desk with coordination+int+1482+3914664481228082529@CFDE.groups.io