### PR TITLE
Broken Link to CFDE Code of Conduct

### DIFF
--- a/NewRepositoryGuide.md
+++ b/NewRepositoryGuide.md
@@ -16,7 +16,7 @@ If the repository will not host much code, consider whether a mailing list or Sl
   - Repositories that are created in the CFDE organization are able to
     take advantage of Github teams in the CFDE organization.
   - All repositories that are part of the CFDE project are subject to
-    the [CFDE Code of Conduct](CODE_OF_CONDUCT.md).
+    the [CFDE Code of Conduct](https://github.com/nih-cfde/organization/blob/master/NewRepositoryGuide.md).
 
 **2) Decide whether to make your repository public or private.**
 

--- a/NewRepositoryGuide.md
+++ b/NewRepositoryGuide.md
@@ -16,7 +16,7 @@ If the repository will not host much code, consider whether a mailing list or Sl
   - Repositories that are created in the CFDE organization are able to
     take advantage of Github teams in the CFDE organization.
   - All repositories that are part of the CFDE project are subject to
-    the [CFDE Code of Conduct](https://github.com/nih-cfde/organization/blob/master/CODEOFCONDUCT.md).
+    the [CFDE Code of Conduct](./CODEOFCONDUCT.md).
 
 **2) Decide whether to make your repository public or private.**
 
@@ -73,8 +73,7 @@ If the repository will not host much code, consider whether a mailing list or Sl
 **7) Add a `CONTRIBUTING.md` that explains how to contribute to the
 repository.**
 
-  - Sample `CONTRIBUTING.md`:
-    <https://github.com/nih-cfde/organization/blob/master/CONTRIBUTING.md>
+  - Sample [CONTRIBUTING.md](./CONTRIBUTING.md)
 
 
 <a name="addendum"></a>

--- a/NewRepositoryGuide.md
+++ b/NewRepositoryGuide.md
@@ -16,7 +16,7 @@ If the repository will not host much code, consider whether a mailing list or Sl
   - Repositories that are created in the CFDE organization are able to
     take advantage of Github teams in the CFDE organization.
   - All repositories that are part of the CFDE project are subject to
-    the [CFDE Code of Conduct](https://github.com/nih-cfde/organization/blob/master/NewRepositoryGuide.md).
+    the [CFDE Code of Conduct](https://github.com/nih-cfde/organization/blob/master/CODEOFCONDUCT.md).
 
 **2) Decide whether to make your repository public or private.**
 


### PR DESCRIPTION
Added the full directory to the link for CFDE Code of Conduct.
@ACharbonneau There are two help desk links on this page. Do they get sent to Onboarding mailing list or should they remain as they are? Neither sound as though they belong to the Code of Conduct mailing list. So I don't if they should remain to be sent to you or onboarding team.